### PR TITLE
Fix typos in package description

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 [tool.poetry]
 name = "sphinx-data-viewer"
 version = "0.1.3"
-description = "Sphinx extension to show dta in an interacitve list view"
+description = "Sphinx extension to show data in an interactive list view"
 authors = ["team useblocks"]
 license = "MIT"
 readme = "README.rst"


### PR DESCRIPTION
I made an assumption on the `dta` typo.